### PR TITLE
fix broken lines:

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -490,7 +490,7 @@ function parse_and_run_crossword(raw_crossword) {
     // Remove lines that contain only non-letter characters
     const cleaned_parts = parts.map(part => {
         return part.split('\n')
-                   .filter(line => /[a-zA-Z]/.test(line))
+                   .filter(line => /[a-zA-Z]/.test(line)) // This checks if the line contains exclusively non-character characters (e.g. punctuation)
                    .join('\n');
     });
     // Crossword is the 3rd from the end

--- a/static/script.js
+++ b/static/script.js
@@ -486,13 +486,18 @@ document.getElementById('toggle-night-mode').addEventListener('click', function 
 });
 
 function parse_and_run_crossword(raw_crossword) {
-    const parts = raw_crossword.split('\n\n')
-    console.log(parts)
-    //Crossword is the 3rd from the end
-    const parsed_crossword = parts[parts.length - 3]
-    //Hints is the two last ones combined by \n\n
-    const hints = parts.slice(-2).join('\n\n')
-    usecase(parsed_crossword, hints)
+    const parts = raw_crossword.split('\n\n');
+    // Remove lines that contain only non-letter characters
+    const cleaned_parts = parts.map(part => {
+        return part.split('\n')
+                   .filter(line => /[a-zA-Z]/.test(line))
+                   .join('\n');
+    });
+    // Crossword is the 3rd from the end
+    const parsed_crossword = cleaned_parts[cleaned_parts.length - 3];
+    // Hints is the two last ones combined by \n\n
+    const hints = cleaned_parts.slice(-2).join('\n\n');
+    usecase(parsed_crossword, hints);
 }
 
 /**


### PR DESCRIPTION
- empty last lines, e.g. `201202`

Before:
![image](https://github.com/arpheno/crossword/assets/38767382/05fb74d7-e8bc-4823-ab3a-fedcba07fb94)

After:
![image](https://github.com/arpheno/crossword/assets/38767382/1e0acc69-9f05-4c23-969a-721a2ac86207)

There were dots end of the line in the [raw puzzle](https://nytsyn.pzzl.com/nytsyn-crossword-mh/nytsyncrossword?date=201202):
![image](https://github.com/arpheno/crossword/assets/38767382/4e9faccc-0b29-4be0-b867-68b2c45c99e8)
Not sure why but don't seem particularly useful.


